### PR TITLE
feat: Display node summary and URL in DOT output

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,15 @@
 Visualize your Nix flake.lock!
 
 This project provides facilities for parsing and analyzing `flake.lock` files.
+
+## Usage
+
+```
+$ flake-graph flake.lock | dot -Tsvg > flake-graph.svg
+```
+
+## Sample
+
+![image](https://gist.githubusercontent.com/nikitawootten/a0b5b3e0afdaaa8e02ace16b955da7ec/raw/flake-graph.svg)
+
+Flake lock diagram of [`nikitawotten/infra`](https://github.com/nikitawootten/infra)


### PR DESCRIPTION
- DOT specify LR layout (easier to consume on web pages as dependency graphs are often wide and shallow)
- Add usage and sample to the README