### PR TITLE
feat: Add node ref for git type

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -15,6 +15,7 @@ impl Node {
     fn digest(&self) -> Option<String> {
         match &self.locked {
             Some(locked) => Some(match &locked.reference {
+                lock::NodeRef::Git(git) => format!("git::{}", git.url),
                 lock::NodeRef::GitHub(github) => {
                     format!("github::{}/{}", github.owner, github.repo)
                 }

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -28,10 +28,20 @@ pub struct NodeLock {
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
 #[serde(rename_all = "lowercase", tag = "type")]
 pub enum NodeRef {
+    Git(NodeRefGit),
     GitHub(NodeRefGitHub),
     Indirect(NodeRefIndirect),
     Tarball(NodeRefTarball),
     Path(NodeRefPath),
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
+pub struct NodeRefGit {
+    #[serde(rename = "ref")]
+    pub reference: Option<String>,
+    #[serde(rename = "rev")]
+    pub revision: Option<String>,
+    pub url: String,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,4 @@
-use flake_graph::lock::{FlakeLock, Node, NodeInput, NodeLock, NodeRef, NodeRefGitHub};
+use flake_graph::lock::{FlakeLock, Node, NodeInput, NodeLock, NodeRef, NodeRefGit, NodeRefGitHub};
 use std::collections::HashMap;
 
 fn nixpkgs_node() -> Node {
@@ -38,10 +38,33 @@ pub fn simple_lock() -> FlakeLock {
                 Node {
                     locked: None,
                     original: None,
-                    inputs: HashMap::from([(
-                        "nixpkgs".to_string(),
-                        NodeInput::Direct("nixpkgs".to_string()),
-                    )]),
+                    inputs: HashMap::from([
+                        (
+                            "nixpkgs".to_string(),
+                            NodeInput::Direct("nixpkgs".to_string()),
+                        ),
+                        ("yants".to_string(), NodeInput::Direct("yants".to_string())),
+                    ]),
+                },
+            ),
+            (
+                "yants".to_string(),
+                Node {
+                    locked: Some(NodeLock {
+                        last_modified: 1645270620,
+                        nar_hash: "sha256-wwkl3K200UbW9Z7BRlVH8HOEXCaVYP2MqZpsF9EhgZg=".to_string(),
+                        reference: NodeRef::Git(NodeRefGit {
+                            url: "https://code.tvl.fyi/depot.git:/nix/yants.git".to_string(),
+                            revision: Some("efeb6dc11eb1a1e88d41dc2093fc5aa31f7abd35".to_string()),
+                            reference: Some("refs/heads/canon".to_string()),
+                        }),
+                    }),
+                    original: Some(NodeRef::Git(NodeRefGit {
+                        url: "https://code.tvl.fyi/depot.git:/nix/yants.git".to_string(),
+                        revision: None,
+                        reference: None,
+                    })),
+                    inputs: HashMap::default(),
                 },
             ),
         ]),

--- a/tests/common/simple_flake.lock
+++ b/tests/common/simple_flake.lock
@@ -18,7 +18,24 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "yants": "yants"
+      }
+    },
+    "yants": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645270620,
+        "narHash": "sha256-wwkl3K200UbW9Z7BRlVH8HOEXCaVYP2MqZpsF9EhgZg=",
+        "ref": "refs/heads/canon",
+        "rev": "efeb6dc11eb1a1e88d41dc2093fc5aa31f7abd35",
+        "revCount": 15,
+        "type": "git",
+        "url": "https://code.tvl.fyi/depot.git:/nix/yants.git"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://code.tvl.fyi/depot.git:/nix/yants.git"
       }
     }
   },


### PR DESCRIPTION
This tool is cool, but it doesn't work with flakes that contain non-flake inputs (a.k.a ones with git types). This is what happens when I try to run it on the flake from [NGIpkgs](https://github.com/ngi-nix/ngipkgs/):

```shellSession
$ nix run github:nikitawootten/flake-graph -- ~/ngipkgs/flake.lock
thread 'main' panicked at src/main.rs:17:36:
Should have been able to parse flake lock: Error("unknown variant `git`, expected one of `github`, `indirect`, `tarball`, `path`", line: 362, column: 7)
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::result::unwrap_failed
   3: flake_graph::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

This PR adds the missing `Git` type and thus fixes the error, above:

```shellSession
$ ./result/bin/flake-graph ~/ngipkgs/flake.lock
digraph {
    node [colorscheme=oranges9 shape=record]
    rankdir=LR
    0 [ label = "dream2nix\ngithub:nix-community/dream2nix", URL = "https://github.com/nix-community/dream2nix/tree/8ce6284ff58208ed8961681276f82c2f8f978ef4"]
    1 [ label = "purescript-overlay\ngithub:thomashoneyman/purescript-overlay", URL = "https://github.com/thomashoneyman/purescript-overlay/tree/4ad4c15d07bd899d7346b331f377606631eb0ee4"]
    2 [ label = "slimlock\ngithub:thomashoneyman/slimlock", URL = "https://github.com/thomashoneyman/slimlock/tree/cf72723f59e2340d24881fd7bf61cb113b4c407c"]
    3 [ label = "yants"]
...
```