### PR TITLE
build: Add pretty assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "env_filter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,6 +165,7 @@ dependencies = [
  "env_logger",
  "log",
  "petgraph",
+ "pretty_assertions",
  "serde",
  "serde_json",
 ]
@@ -228,6 +235,16 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -545,3 +562,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ petgraph = { version = "0.6.4", features = ["serde-1"] }
 clap = { version = "4.5.26", features = ["derive"] }
 log = "0.4.24"
 env_logger = "0.11.6"
+
+[dev-dependencies]
+pretty_assertions = "1.4.1"

--- a/tests/parse_lock.rs
+++ b/tests/parse_lock.rs
@@ -1,4 +1,5 @@
 pub mod common;
+use pretty_assertions::assert_eq;
 
 use common::{bound_lock, simple_lock, BOUND_LOCK_STR, SIMPLE_LOCK_STR};
 use flake_graph::lock::FlakeLock;


### PR DESCRIPTION
Just a small addition that I found really useful when adding tests to https://github.com/nikitawootten/flake-graph/pull/3. Compare the following outputs:

<details><summary>Currently</summary>
<p>

This of course will look less readable in a terminal since the text will be wrapped, but it would be pretty difficult to spot the different nonetheless.

```shellSession
---- parse_simple_lock stdout ----
thread 'parse_simple_lock' panicked at tests/parse_lock.rs:10:5:
assertion `left == right` failed
  left: FlakeLock { nodes: {"nixpkgs": Node { locked: Some(NodeLock { last_modified: 1692742407, nar_hash: "sha256-faLAAAAAAAAAAAfzQr19B464eyADP3Ux7A/vjKIY=", reference: GitHub(NodeRefGitHub { owner: "NixOS", reference: None, revision: Some("aasdajskdjaskdj542af3f818274c38305c1e00604c"), repo: "nixpkgs" }) }), original: Some(GitHub(NodeRefGitHub { owner: "NixOS", reference: Some("nixpkgs-unstable"), revision: None, repo: "nixpkgs" })), inputs: {} }, "root": Node { locked: None, original: None, inputs: {"nixpkgs": Direct("nixpkgs")} }}, root: "root", version: 7 }
 right: FlakeLock { nodes: {"nixpkgs": Node { locked: Some(NodeLock { last_modified: 1692742407, nar_hash: "sha256-faLzZ2u3Wki8h9ykEfzQr19B464eyADP3Ux7A/vjKIY=", reference: GitHub(NodeRefGitHub { owner: "NixOS", reference: None, revision: Some("a2eca347ae1e542af3f818274c38305c1e00604c"), repo: "nixpkgs" }) }), original: Some(GitHub(NodeRefGitHub { owner: "NixOS", reference: Some("nixpkgs-unstable"), revision: None, repo: "nixpkgs" })), inputs: {} }, "root": Node { locked: None, original: None, inputs: {"nixpkgs": Direct("nixpkgs")} }}, root: "root", version: 7 }
```

</p>
</details> 

<details><summary>With pretty assertions</summary>
<p>

You will get an actual diff of what's there and what's expected with nice formatting.

```shellSession
---- parse_simple_lock stdout ----
thread 'parse_simple_lock' panicked at tests/parse_lock.rs:10:5:
assertion failed: `(left == right)`

Diff < left / right > :
 FlakeLock {
     nodes: {
>        "root": Node {
>            locked: None,
>            original: None,
>            inputs: {
>                "nixpkgs": Direct(
>                    "nixpkgs",
>                ),
>            },
>        },
         "nixpkgs": Node {
             locked: Some(
                 NodeLock {
                     last_modified: 1692742407,
<                    nar_hash: "sha256-faLAAAAAAAAAAAfzQr19B464eyADP3Ux7A/vjKIY=",
>                    nar_hash: "sha256-faLzZ2u3Wki8h9ykEfzQr19B464eyADP3Ux7A/vjKIY=",
                     reference: GitHub(
                         NodeRefGitHub {
                             owner: "NixOS",
                             reference: None,
                             revision: Some(
<                                "aasdajskdjaskdj542af3f818274c38305c1e00604c",
>                                "a2eca347ae1e542af3f818274c38305c1e00604c",
                             ),
                             repo: "nixpkgs",
                         },
                     ),
                 },
             ),
             original: Some(
                 GitHub(
                     NodeRefGitHub {
                         owner: "NixOS",
                         reference: Some(
                             "nixpkgs-unstable",
                         ),
                         revision: None,
                         repo: "nixpkgs",
                     },
                 ),
             ),
             inputs: {},
<        },
<        "root": Node {
<            locked: None,
<            original: None,
<            inputs: {
<                "nixpkgs": Direct(
<                    "nixpkgs",
<                ),
<            },
         },
     },
     root: "root",
     version: 7,
 }

```

</p>
</details> 