### PR TITLE
refactor: Apply clippy lints

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -159,7 +159,7 @@ impl NodeGraph {
         duplicates
     }
 
-    pub fn to_dot<'a>(&self) -> String {
+    pub fn to_dot(&self) -> String {
         let similarity_map = self.similarity_map();
 
         let node_labeller: &dyn Fn(_, (_, &Node)) -> String = &|_, (_, n)| {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -143,22 +143,18 @@ impl From<lock::FlakeLock> for NodeGraph {
 impl NodeGraph {
     pub fn similarity_map(&self) -> HashMap<String, Vec<NodeIndex>> {
         let mut duplicates = HashMap::<String, Vec<NodeIndex>>::new();
-        self.graph
-            .node_indices()
-            .for_each(|index| match self.graph.node_weight(index) {
-                Some(weight) => {
-                    match weight.digest() {
-                        Some(digest) => match duplicates.get_mut(&digest) {
-                            Some(indices) => indices.push(index),
-                            _ => {
-                                duplicates.insert(digest, vec![index]);
-                            }
-                        },
-                        _ => {}
-                    };
-                }
-                _ => {}
-            });
+        self.graph.node_indices().for_each(|index| {
+            if let Some(weight) = self.graph.node_weight(index) {
+                if let Some(digest) = weight.digest() {
+                    match duplicates.get_mut(&digest) {
+                        Some(indices) => indices.push(index),
+                        _ => {
+                            duplicates.insert(digest, vec![index]);
+                        }
+                    }
+                };
+            }
+        });
 
         duplicates
     }
@@ -170,24 +166,20 @@ impl NodeGraph {
             let mut label = n.name.clone();
             let mut url: Option<String> = None;
 
-            match &n.locked {
-                Some(locked) => match &locked.reference {
-                    lock::NodeRef::GitHub(github) => {
-                        label.push_str(&format!("\\ngithub:{}/{}", github.owner, github.repo));
-                        url = match &github.revision {
-                            Some(rev) => Some(format!(
-                                "https://github.com/{}/{}/tree/{}",
-                                github.owner, github.repo, rev
-                            )),
-                            _ => Some(format!(
-                                "https://github.com/{}/{}",
-                                github.owner, github.repo
-                            )),
-                        };
-                    }
-                    _ => {}
-                },
-                _ => {}
+            if let Some(locked) = &n.locked {
+                if let lock::NodeRef::GitHub(github) = &locked.reference {
+                    label.push_str(&format!("\\ngithub:{}/{}", github.owner, github.repo));
+                    url = match &github.revision {
+                        Some(rev) => Some(format!(
+                            "https://github.com/{}/{}/tree/{}",
+                            github.owner, github.repo, rev
+                        )),
+                        _ => Some(format!(
+                            "https://github.com/{}/{}",
+                            github.owner, github.repo
+                        )),
+                    };
+                }
             }
 
             let mut node_label = format!("label = \"{}\"", label,);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -13,18 +13,15 @@ pub struct Node {
 
 impl Node {
     fn digest(&self) -> Option<String> {
-        match &self.locked {
-            Some(locked) => Some(match &locked.reference {
-                lock::NodeRef::Git(git) => format!("git::{}", git.url),
-                lock::NodeRef::GitHub(github) => {
-                    format!("github::{}/{}", github.owner, github.repo)
-                }
-                lock::NodeRef::Indirect(indirect) => format!("indirect::{}", indirect.id),
-                lock::NodeRef::Tarball(tarball) => format!("tarball::{}", tarball.url),
-                lock::NodeRef::Path(path) => format!("path::{}", path.path),
-            }),
-            _ => None,
-        }
+        self.locked.as_ref().map(|locked| match &locked.reference {
+            lock::NodeRef::Git(git) => format!("git::{}", git.url),
+            lock::NodeRef::GitHub(github) => {
+                format!("github::{}/{}", github.owner, github.repo)
+            }
+            lock::NodeRef::Indirect(indirect) => format!("indirect::{}", indirect.id),
+            lock::NodeRef::Tarball(tarball) => format!("tarball::{}", tarball.url),
+            lock::NodeRef::Path(path) => format!("path::{}", path.path),
+        })
     }
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -220,13 +220,13 @@ impl NodeGraph {
     }
 }
 
-impl Into<lock::FlakeLock> for NodeGraph {
+impl From<NodeGraph> for lock::FlakeLock {
     // TODO
-    fn into(self) -> lock::FlakeLock {
+    fn from(val: NodeGraph) -> Self {
         lock::FlakeLock {
             nodes: HashMap::default(),
             root: "".to_string(),
-            version: self.version,
+            version: val.version,
         }
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -97,7 +97,7 @@ fn process_node_inputs<'a>(
     // Mark the edge as visited so that it is not processed twice
     visited_nodes.insert(node_index);
 
-    return (graph, visited_nodes);
+    (graph, visited_nodes)
 }
 
 impl From<lock::FlakeLock> for NodeGraph {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -28,7 +28,7 @@ pub const SIMPLE_LOCK_STR: &str = include_str!("./simple_flake.lock");
 
 /// Struct representation of a simple lock file consisting of one input
 pub fn simple_lock() -> FlakeLock {
-    return FlakeLock {
+    FlakeLock {
         root: "root".to_string(),
         version: 7,
         nodes: HashMap::from([
@@ -68,7 +68,7 @@ pub fn simple_lock() -> FlakeLock {
                 },
             ),
         ]),
-    };
+    }
 }
 
 /// JSON string of a lock file with an input bound through a `follows` directive
@@ -76,7 +76,7 @@ pub const BOUND_LOCK_STR: &str = include_str!("./bound_flake.lock");
 
 // Struct representation of a lock file with an input bound through a `follows` directive
 pub fn bound_lock() -> FlakeLock {
-    return FlakeLock {
+    FlakeLock {
         root: "root".to_string(),
         version: 7,
         nodes: HashMap::from([
@@ -124,7 +124,7 @@ pub fn bound_lock() -> FlakeLock {
                 },
             ),
         ]),
-    };
+    }
 }
 
 /// JSON string of a lock file with an input loop


### PR DESCRIPTION
These are non-breaking [Clippy lints](https://github.com/rust-lang/rust-clippy) and most of them are for better code readability. You can learn more about each one with the associated URLs in the commit descriptions.