### PR TITLE
feat: `--size` option to display input sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ $ nix shell github:nikitawootten/flake-graph nixpkgs#graphviz \
     --command sh -c 'flake-graph flake.lock | dot -Tsvg > flake-lock.svg'
 ```
 
+### Input sizes
+
+Pass `--size` to annotate each input with the on-disk size of its source in the Nix store.
+
+```sh
+$ nix shell github:nikitawootten/flake-graph nixpkgs#graphviz \
+    --command sh -c 'flake-graph --size flake.lock | dot -Tsvg > flake-lock.svg'
+```
+
+This invokes `nix` to resolve each input and may fetch inputs from the network if they are not already in the store.
+
 ## Sample
 
 ![image](https://gist.githubusercontent.com/nikitawootten/a0b5b3e0afdaaa8e02ace16b955da7ec/raw/flake-graph.svg)

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
 use crate::lock;
+use crate::size::{self, SizeError};
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
 pub struct Node {
@@ -143,7 +144,58 @@ impl From<lock::FlakeLock> for NodeGraph {
     }
 }
 
+/// Source sizes for a [`NodeGraph`], keyed by graph node index.
+#[derive(Debug, Default, PartialEq)]
+pub struct SizeSummary {
+    /// The source size in bytes for each node.
+    pub per_node: HashMap<NodeIndex, u64>,
+    /// Sum of every node's source size (duplicated sources counted once per node).
+    pub total: u64,
+    /// Sum of each distinct source's size (duplicated sources counted once).
+    pub deduped_total: u64,
+    /// Bytes attributable to duplicated sources (`total - deduped_total`).
+    pub wasted: u64,
+}
+
 impl NodeGraph {
+    /// Resolve the source size of every node.
+    pub fn source_sizes(&self, flake_dir: &str) -> Result<SizeSummary, SizeError> {
+        let mut summary = SizeSummary::default();
+
+        for indices in self.similarity_map().values() {
+            let locked = indices
+                .iter()
+                .find_map(|index| self.graph.node_weight(*index))
+                .and_then(|node| node.locked.as_ref());
+            let locked = match locked {
+                Some(locked) => locked,
+                None => continue,
+            };
+
+            log::trace!("Resolving source size for digest shared by {:?}", indices);
+            let size = size::source_size(locked)?;
+
+            summary.deduped_total += size;
+            for index in indices {
+                summary.per_node.insert(*index, size);
+                summary.total += size;
+            }
+        }
+
+        // The root node needs to be sized separately
+        if let std::collections::hash_map::Entry::Vacant(entry) = summary.per_node.entry(self.root)
+        {
+            log::trace!("Resolving source size for root flake at {}", flake_dir);
+            let size = size::flake_source_size(flake_dir)?;
+            entry.insert(size);
+            summary.total += size;
+            summary.deduped_total += size;
+        }
+
+        summary.wasted = summary.total - summary.deduped_total;
+        Ok(summary)
+    }
+
     pub fn similarity_map(&self) -> HashMap<String, Vec<NodeIndex>> {
         let mut duplicates = HashMap::<String, Vec<NodeIndex>>::new();
         self.graph.node_indices().for_each(|index| {
@@ -162,10 +214,10 @@ impl NodeGraph {
         duplicates
     }
 
-    pub fn to_dot(&self) -> String {
+    pub fn to_dot(&self, sizes: Option<&SizeSummary>) -> String {
         let similarity_map = self.similarity_map();
 
-        let node_labeller: &dyn Fn(_, (_, &Node)) -> String = &|_, (_, n)| {
+        let node_labeller: &dyn Fn(_, (NodeIndex, &Node)) -> String = &|_, (idx, n)| {
             let mut label = n.name.clone();
             let mut url: Option<String> = None;
 
@@ -200,6 +252,12 @@ impl NodeGraph {
                 }
             }
 
+            if let Some(sizes) = sizes {
+                if let Some(bytes) = sizes.per_node.get(&idx) {
+                    label.push_str(&format!("\\n{}", size::human_bytes(*bytes)));
+                }
+            }
+
             let mut node_label = format!("label = \"{}\"", label,);
 
             if let Some(url) = url {
@@ -228,12 +286,21 @@ impl NodeGraph {
             node_labeller,
         );
 
+        let graph_label = match sizes {
+            Some(sizes) => format!(
+                "    label=\"total: {}  (duplicated: {})\"\n    labelloc=t\n",
+                size::human_bytes(sizes.total),
+                size::human_bytes(sizes.wasted)
+            ),
+            None => String::new(),
+        };
+
         format!(
             r#"digraph {{
     node [colorscheme=oranges9 shape=record]
     rankdir=LR
-{:?}}}"#,
-            dot
+{}{:?}}}"#,
+            graph_label, dot
         )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod graph;
 pub mod lock;
+pub mod size;

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -38,9 +38,9 @@ pub enum NodeRef {
 
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
 pub struct NodeRefGit {
-    #[serde(rename = "ref")]
+    #[serde(rename = "ref", skip_serializing_if = "Option::is_none")]
     pub reference: Option<String>,
-    #[serde(rename = "rev")]
+    #[serde(rename = "rev", skip_serializing_if = "Option::is_none")]
     pub revision: Option<String>,
     pub url: String,
 }
@@ -48,9 +48,9 @@ pub struct NodeRefGit {
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
 pub struct NodeRefGitHub {
     pub owner: String,
-    #[serde(rename = "ref")]
+    #[serde(rename = "ref", skip_serializing_if = "Option::is_none")]
     pub reference: Option<String>,
-    #[serde(rename = "rev")]
+    #[serde(rename = "rev", skip_serializing_if = "Option::is_none")]
     pub revision: Option<String>,
     pub repo: String,
 }
@@ -58,9 +58,9 @@ pub struct NodeRefGitHub {
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
 pub struct NodeRefGitLab {
     pub owner: String,
-    #[serde(rename = "ref")]
+    #[serde(rename = "ref", skip_serializing_if = "Option::is_none")]
     pub reference: Option<String>,
-    #[serde(rename = "rev")]
+    #[serde(rename = "rev", skip_serializing_if = "Option::is_none")]
     pub revision: Option<String>,
     pub repo: String,
     pub host: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,15 +6,43 @@ use flake_graph::{graph::NodeGraph, lock::FlakeLock};
 struct Args {
     /// Path to the given flake.lock
     input: String,
+
+    /// Display the Nix store size of each input's source.
+    ///
+    /// Requires the `nix` binary and may fetch inputs from the network.
+    #[arg(long)]
+    size: bool,
 }
 
 fn main() {
     env_logger::init();
 
     let args = Args::parse();
-    let raw = std::fs::read_to_string(args.input).expect("Should have been able to read the file");
+    let raw = std::fs::read_to_string(&args.input).expect("Should have been able to read the file");
     let parsed: FlakeLock =
         serde_json::from_str(&raw).expect("Should have been able to parse flake lock");
     let graph = NodeGraph::from(parsed);
-    println!("{}", graph.to_dot());
+
+    let sizes = if args.size {
+        // The root flake's source is sized from the directory containing the flake.lock.
+        let flake_dir = std::path::Path::new(&args.input)
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
+        let summary = graph
+            .source_sizes(&flake_dir.to_string_lossy())
+            .unwrap_or_else(|err| panic!("Failed to compute input sizes: {}", err));
+        eprintln!(
+            "total source size: {} (deduplicated: {}, duplicated: {})",
+            flake_graph::size::human_bytes(summary.total),
+            flake_graph::size::human_bytes(summary.deduped_total),
+            flake_graph::size::human_bytes(summary.wasted),
+        );
+        Some(summary)
+    } else {
+        None
+    };
+
+    println!("{}", graph.to_dot(sizes.as_ref()));
 }

--- a/src/size.rs
+++ b/src/size.rs
@@ -1,0 +1,215 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::process::Command;
+
+use serde::Deserialize;
+
+use crate::lock;
+
+/// Experimental features required to use `nix eval`/`nix path-info`.
+const EXPERIMENTAL_FEATURES: &str = "nix-command flakes";
+
+/// Failure to resolve the size of an input's source.
+#[derive(Debug)]
+pub enum SizeError {
+    /// The `nix` binary could not be found on `PATH`.
+    NixNotFound,
+    /// `nix eval` (fetching the source via `fetchTree`) failed.
+    Eval(String),
+    /// `nix path-info` failed or returned no entries.
+    PathInfo(String),
+    /// The JSON emitted by `nix` could not be parsed.
+    Json(serde_json::Error),
+}
+
+impl fmt::Display for SizeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SizeError::NixNotFound => write!(
+                f,
+                "the `nix` binary could not be found on PATH (required for --size)"
+            ),
+            SizeError::Eval(msg) => write!(f, "`nix eval` failed: {}", msg),
+            SizeError::PathInfo(msg) => write!(f, "`nix path-info` failed: {}", msg),
+            SizeError::Json(err) => write!(f, "could not parse nix JSON output: {}", err),
+        }
+    }
+}
+
+impl std::error::Error for SizeError {}
+
+impl From<serde_json::Error> for SizeError {
+    fn from(err: serde_json::Error) -> Self {
+        SizeError::Json(err)
+    }
+}
+
+/// A single entry of `nix path-info --json` output.
+#[derive(Deserialize)]
+struct PathInfo {
+    #[serde(rename = "narSize")]
+    nar_size: u64,
+}
+
+/// `nix path-info --json` output
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum PathInfoResponse {
+    Array(Vec<PathInfo>),
+    Map(HashMap<String, PathInfo>),
+}
+
+impl PathInfoResponse {
+    fn nar_size(&self) -> Option<u64> {
+        match self {
+            PathInfoResponse::Array(entries) => entries.first().map(|e| e.nar_size),
+            PathInfoResponse::Map(entries) => entries.values().next().map(|e| e.nar_size),
+        }
+    }
+}
+
+fn escape_nix_string(input: &str) -> String {
+    input
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace("${", "\\${")
+}
+
+/// Run `nix` with the given arguments, returning stdout on success.
+fn run_nix(args: &[&str]) -> Result<String, SizeError> {
+    let output = Command::new("nix").args(args).output().map_err(|err| {
+        if err.kind() == std::io::ErrorKind::NotFound {
+            SizeError::NixNotFound
+        } else {
+            SizeError::Eval(err.to_string())
+        }
+    })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(SizeError::Eval(stderr));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Relevant fields of `nix flake metadata --json` output.
+#[derive(Deserialize)]
+struct FlakeMetadata {
+    /// Store path of the flake's source tree.
+    path: String,
+}
+
+/// Read the source's own NAR size of a store path via `nix path-info --json`.
+fn path_info_size(store_path: &str) -> Result<u64, SizeError> {
+    let raw = run_nix(&[
+        "path-info",
+        "--json",
+        "--extra-experimental-features",
+        EXPERIMENTAL_FEATURES,
+        store_path,
+    ])
+    .map_err(|err| match err {
+        SizeError::Eval(msg) => SizeError::PathInfo(msg),
+        other => other,
+    })?;
+
+    let response: PathInfoResponse = serde_json::from_str(&raw)?;
+    response
+        .nar_size()
+        .ok_or_else(|| SizeError::PathInfo(format!("no entry for store path {}", store_path)))
+}
+
+/// Resolve the store path of a locked reference and return its source's own size in bytes.
+///
+/// The locked reference is fetched into the store if not already present.
+pub fn source_size(locked: &lock::NodeLock) -> Result<u64, SizeError> {
+    let json = serde_json::to_string(locked)?;
+    let expr = format!(
+        "(builtins.fetchTree (builtins.fromJSON \"{}\")).outPath",
+        escape_nix_string(&json)
+    );
+
+    let store_path = run_nix(&[
+        "eval",
+        "--raw",
+        "--extra-experimental-features",
+        EXPERIMENTAL_FEATURES,
+        "--expr",
+        &expr,
+    ])?;
+
+    path_info_size(store_path.trim())
+}
+
+/// Resolve the source size of the root node (local flake) from its directory.
+///
+/// Unlike locked inputs, the root flake is not described by `flake.lock`, so its source is
+/// resolved via `nix flake metadata`, which reports the store path of the flake source (the
+/// git-tracked tree, copied into the store).
+pub fn flake_source_size(flake_dir: &str) -> Result<u64, SizeError> {
+    let raw = run_nix(&[
+        "flake",
+        "metadata",
+        "--json",
+        "--extra-experimental-features",
+        EXPERIMENTAL_FEATURES,
+        flake_dir,
+    ])?;
+
+    let metadata: FlakeMetadata = serde_json::from_str(&raw)?;
+    path_info_size(&metadata.path)
+}
+
+/// Format a byte count as a short human-readable string using IEC (binary) units, matching
+/// Nix's own conventions (e.g. `1536` -> `"1.5 KiB"`).
+pub fn human_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{} B", bytes)
+    } else {
+        format!("{:.1} {}", value, UNITS[unit])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn human_bytes_boundaries() {
+        assert_eq!(human_bytes(0), "0 B");
+        assert_eq!(human_bytes(1023), "1023 B");
+        assert_eq!(human_bytes(1024), "1.0 KiB");
+        assert_eq!(human_bytes(1536), "1.5 KiB");
+        assert_eq!(human_bytes(1024 * 1024), "1.0 MiB");
+        assert_eq!(human_bytes(1024 * 1024 * 1024), "1.0 GiB");
+    }
+
+    #[test]
+    fn escape_nix_string_specials() {
+        assert_eq!(escape_nix_string(r#"a"b"#), r#"a\"b"#);
+        assert_eq!(escape_nix_string(r"a\b"), r"a\\b");
+        assert_eq!(escape_nix_string("a${b}"), "a\\${b}");
+    }
+
+    #[test]
+    fn path_info_parses_array_form() {
+        let raw = r#"[{"path":"/nix/store/x","narSize":4096,"other":1}]"#;
+        let parsed: PathInfoResponse = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed.nar_size(), Some(4096));
+    }
+
+    #[test]
+    fn path_info_parses_map_form() {
+        let raw = r#"{"/nix/store/x":{"narSize":8192,"other":1}}"#;
+        let parsed: PathInfoResponse = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed.nar_size(), Some(8192));
+    }
+}

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1,25 +1,75 @@
 pub mod common;
 
 use common::{bound_lock, simple_lock, LOOPED_LOCK_STR};
-use flake_graph::{graph::NodeGraph, lock::FlakeLock};
+use flake_graph::{
+    graph::{NodeGraph, SizeSummary},
+    lock::FlakeLock,
+    size,
+};
+use std::collections::HashMap;
 
 #[test]
 fn build_simple_lock_graph() {
     let lock = simple_lock();
     let graph = NodeGraph::from(lock);
-    println!("{}", graph.to_dot());
+    println!("{}", graph.to_dot(None));
 }
 
 #[test]
 fn build_bound_lock_graph() {
     let lock = bound_lock();
     let graph = NodeGraph::from(lock);
-    println!("{}", graph.to_dot());
+    println!("{}", graph.to_dot(None));
 }
 
 #[test]
 fn build_looped_lock_graph() {
     let parsed: FlakeLock = serde_json::from_str(LOOPED_LOCK_STR).unwrap();
     let graph = NodeGraph::from(parsed);
-    println!("{}", graph.to_dot());
+    println!("{}", graph.to_dot(None));
+}
+
+/// A locked node re-serializes into a clean `builtins.fetchTree` argument.
+#[test]
+fn locked_node_serializes_for_fetch_tree() {
+    let nixpkgs = simple_lock().nodes.remove("nixpkgs").unwrap();
+    let json = serde_json::to_string(&nixpkgs.locked.unwrap()).unwrap();
+    assert!(json.contains("\"type\":\"github\""), "got: {}", json);
+    assert!(json.contains("\"narHash\""), "got: {}", json);
+    assert!(json.contains("\"rev\""), "got: {}", json);
+}
+
+/// When a size summary is supplied, node labels gain a size line and the graph gains a total.
+#[test]
+fn to_dot_renders_sizes() {
+    let graph = NodeGraph::from(simple_lock());
+    let nixpkgs = graph
+        .graph
+        .node_indices()
+        .find(|i| graph.graph[*i].name == "nixpkgs")
+        .unwrap();
+
+    let summary = SizeSummary {
+        per_node: HashMap::from([(nixpkgs, 1536)]),
+        total: 1536,
+        deduped_total: 1536,
+        wasted: 0,
+    };
+
+    let dot = graph.to_dot(Some(&summary));
+    assert!(dot.contains("1.5 KiB"), "node size missing in:\n{}", dot);
+    assert!(
+        dot.contains("total: 1.5 KiB"),
+        "graph total missing in:\n{}",
+        dot
+    );
+}
+
+/// Ignored due to dependency on nix command and network.
+#[test]
+#[ignore]
+fn source_size_resolves_real_input() {
+    let nixpkgs = simple_lock().nodes.remove("nixpkgs").unwrap();
+    let bytes = size::source_size(&nixpkgs.locked.unwrap()).expect("should resolve size");
+    assert!(bytes > 0, "expected a non-zero source size");
 }


### PR DESCRIPTION
- `--size` option calls the `nix` command to get the store paths for each input and the root node, and to get the store path's size on disk
- Total size and size wasted by duplicated nodes is also reported
- Add `--size` usage to the README