### PR TITLE
feat(flake): Add meta.mainProgram to the package for easier execution

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,12 +1,15 @@
-{ pkgs ? import ./pkgs.nix }:
+{
+  pkgs ? import ./pkgs.nix,
+  lib ? pkgs.lib
+}:
 let
-  manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
+  manifest = (lib.importTOML ./Cargo.toml).package;
 in
 pkgs.rustPlatform.buildRustPackage {
   pname = manifest.name;
   version = manifest.version;
   cargoLock.lockFile = ./Cargo.lock;
-  src = pkgs.lib.cleanSource ./.;
+  src = lib.cleanSource ./.;
 
   doCheck = true;
   checkPhase = ''
@@ -14,4 +17,12 @@ pkgs.rustPlatform.buildRustPackage {
     cargoCheckHook
     runHook postCheck
   '';
+
+  meta = {
+    description = "Visualize your Nix flake.lock!";
+    homepage = "https://github.com/nikitawootten/flake-graph";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = manifest.name;
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -5,14 +5,18 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   };
 
-  outputs = { self, nixpkgs }: let 
+  outputs = { self, nixpkgs }: let
       systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       # forEachSystem [ "x86_64-linux" ] (_: { example = true; }) -> { x86_64-linux.example = true }
       forEachSystem = nixpkgs.lib.genAttrs systems;
   in {
-    packages = forEachSystem (system: {
-      default = nixpkgs.legacyPackages.${system}.callPackage ./. { };
-    });
+    packages = forEachSystem (system:
+      let
+        flake-graph = nixpkgs.legacyPackages.${system}.callPackage ./. { };
+      in {
+        inherit flake-graph;
+        default = flake-graph;
+      });
 
     checks = forEachSystem (system: {
       # Build the default package, including tests


### PR DESCRIPTION
This PR adds the `meta` attrset to the package derivation to allow for running `lib.getExe inputs.flake-graph.packages.${system}.flake-graph}`. Also defining both `flake-graph` and `default` flake `packages` to allow for referring to the package by name.