### PR TITLE
feat: Support some missing fields and File input variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_json",
+ "smart-default",
 ]
 
 [[package]]
@@ -339,6 +340,17 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "smart-default"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ petgraph = { version = "0.6.4", features = ["serde-1"] }
 clap = { version = "4.5.26", features = ["derive"] }
 log = "0.4.24"
 env_logger = "0.11.6"
+smart-default = "0.7.1"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -24,6 +24,7 @@ impl Node {
             }
             lock::NodeRef::Indirect(indirect) => format!("indirect::{}", indirect.id),
             lock::NodeRef::Tarball(tarball) => format!("tarball::{}", tarball.url),
+            lock::NodeRef::File(file) => format!("file::{}", file.url),
             lock::NodeRef::Path(path) => format!("path::{}", path.path),
         })
     }

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use smart_default::SmartDefault;
 use std::collections::HashMap;
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
@@ -19,7 +20,7 @@ pub struct Node {
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct NodeLock {
-    pub last_modified: u32,
+    pub last_modified: Option<u32>,
     pub nar_hash: String,
     #[serde(flatten)]
     pub reference: NodeRef,
@@ -33,6 +34,7 @@ pub enum NodeRef {
     GitLab(NodeRefGitLab),
     Indirect(NodeRefIndirect),
     Tarball(NodeRefTarball),
+    File(NodeRefFile),
     Path(NodeRefPath),
 }
 
@@ -55,7 +57,11 @@ pub struct NodeRefGitHub {
     pub repo: String,
 }
 
-#[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
+fn gitlab_default_host() -> String {
+    "gitlab.com".to_string()
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Debug, Clone, SmartDefault)]
 pub struct NodeRefGitLab {
     pub owner: String,
     #[serde(rename = "ref", skip_serializing_if = "Option::is_none")]
@@ -63,6 +69,8 @@ pub struct NodeRefGitLab {
     #[serde(rename = "rev", skip_serializing_if = "Option::is_none")]
     pub revision: Option<String>,
     pub repo: String,
+    #[default = "gitlab.com"]
+    #[serde(default = "gitlab_default_host")]
     pub host: String,
 }
 
@@ -73,6 +81,11 @@ pub struct NodeRefIndirect {
 
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
 pub struct NodeRefTarball {
+    pub url: String,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
+pub struct NodeRefFile {
     pub url: String,
 }
 

--- a/tests/common/missing_fields_flake.lock
+++ b/tests/common/missing_fields_flake.lock
@@ -1,0 +1,40 @@
+{
+  "nodes": {
+    "root": {
+      "inputs": {
+        "determinate-nixd-aarch64-darwin": "determinate-nixd-aarch64-darwin",
+        "nmd": "nmd"
+      }
+    },
+    "nmd": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1666190571,
+        "narHash": "sha256-Z1hc7M9X6L+H83o9vOprijpzhTfOBjd0KmUTnpHAVjA=",
+        "owner": "rycee",
+        "repo": "nmd",
+        "rev": "b75d312b4f33bd3294cd8ae5c2ca8c6da2afc169",
+        "type": "gitlab"
+      },
+      "original": {
+        "owner": "rycee",
+        "repo": "nmd",
+        "type": "gitlab"
+      }
+    },
+    "determinate-nixd-aarch64-darwin": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-LNvx0qZsH8tbdgNfaig/x5Cf4r4UrXfU1m+0bO3D0E4=",
+        "type": "file",
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.21.0/macOS"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.21.0/macOS"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,10 +1,13 @@
-use flake_graph::lock::{FlakeLock, Node, NodeInput, NodeLock, NodeRef, NodeRefGit, NodeRefGitHub};
+use flake_graph::lock::{
+    FlakeLock, Node, NodeInput, NodeLock, NodeRef, NodeRefFile, NodeRefGit, NodeRefGitHub,
+    NodeRefGitLab,
+};
 use std::collections::HashMap;
 
 fn nixpkgs_node() -> Node {
     Node {
         locked: Some(NodeLock {
-            last_modified: 1692742407,
+            last_modified: Some(1692742407),
             nar_hash: "sha256-faLzZ2u3Wki8h9ykEfzQr19B464eyADP3Ux7A/vjKIY=".to_string(),
             reference: NodeRef::GitHub(NodeRefGitHub {
                 owner: "NixOS".to_string(),
@@ -51,7 +54,7 @@ pub fn simple_lock() -> FlakeLock {
                 "yants".to_string(),
                 Node {
                     locked: Some(NodeLock {
-                        last_modified: 1645270620,
+                        last_modified: Some(1645270620),
                         nar_hash: "sha256-wwkl3K200UbW9Z7BRlVH8HOEXCaVYP2MqZpsF9EhgZg=".to_string(),
                         reference: NodeRef::Git(NodeRefGit {
                             url: "https://code.tvl.fyi/depot.git:/nix/yants.git".to_string(),
@@ -84,7 +87,7 @@ pub fn bound_lock() -> FlakeLock {
                 "home-manager".to_string(),
                 Node {
                     locked: Some(NodeLock {
-                        last_modified: 1693187908,
+                        last_modified: Some(1693187908),
                         nar_hash: "sha256-cTcNpsqi1llmUFl9bmCdD0mTyfjhBrNFPhu2W12WXzA=".to_string(),
                         reference: NodeRef::GitHub(NodeRefGitHub {
                             owner: "nix-community".to_string(),
@@ -121,6 +124,73 @@ pub fn bound_lock() -> FlakeLock {
                             NodeInput::Direct("home-manager".to_string()),
                         ),
                     ]),
+                },
+            ),
+        ]),
+    }
+}
+
+/// JSON string of a valid lock file with some missing fields in its inputs.
+pub const MISSING_FIELDS_LOCK_STR: &str = include_str!("./missing_fields_flake.lock");
+
+/// Struct representation of a valid lock file with some missing fields in its inputs.
+pub fn missing_fields_lock() -> FlakeLock {
+    FlakeLock {
+        root: "root".to_string(),
+        version: 7,
+        nodes: HashMap::from([
+            (
+                "root".to_string(),
+                Node {
+                    locked: None,
+                    original: None,
+                    inputs: HashMap::from([
+                        ("nmd".to_string(), NodeInput::Direct("nmd".to_string())),
+                        (
+                            "determinate-nixd-aarch64-darwin".to_string(),
+                            NodeInput::Direct("determinate-nixd-aarch64-darwin".to_string()),
+                        ),
+                    ]),
+                },
+            ),
+            (
+                "nmd".to_string(),
+                Node {
+                    locked: Some(NodeLock {
+                        last_modified: Some(1666190571),
+                        nar_hash: "sha256-Z1hc7M9X6L+H83o9vOprijpzhTfOBjd0KmUTnpHAVjA=".to_string(),
+                        reference: NodeRef::GitLab(NodeRefGitLab {
+                            owner: "rycee".to_string(),
+                            reference: None,
+                            revision: Some("b75d312b4f33bd3294cd8ae5c2ca8c6da2afc169".to_string()),
+                            repo: "nmd".to_string(),
+                            host: "gitlab.com".to_string(),
+                        }),
+                    }),
+                    original: Some(NodeRef::GitLab(NodeRefGitLab {
+                        owner: "rycee".to_string(),
+                        reference: None,
+                        revision: None,
+                        repo: "nmd".to_string(),
+                        host: "gitlab.com".to_string(),
+                    })),
+                    inputs: HashMap::default(),
+                },
+            ),
+            (
+                "determinate-nixd-aarch64-darwin".to_string(),
+                Node {
+                    locked: Some(NodeLock {
+                        last_modified: None,
+                        nar_hash: "sha256-LNvx0qZsH8tbdgNfaig/x5Cf4r4UrXfU1m+0bO3D0E4=".to_string(),
+                        reference: NodeRef::File(NodeRefFile {
+                            url: "https://install.determinate.systems/determinate-nixd/tag/v3.21.0/macOS".to_string(),
+                        }),
+                    }),
+                    original: Some(NodeRef::File(NodeRefFile {
+                            url: "https://install.determinate.systems/determinate-nixd/tag/v3.21.0/macOS".to_string(),
+                    })),
+                    inputs: HashMap::default(),
                 },
             ),
         ]),

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1,6 +1,6 @@
 pub mod common;
 
-use common::{bound_lock, simple_lock, LOOPED_LOCK_STR};
+use common::{bound_lock, missing_fields_lock, simple_lock, LOOPED_LOCK_STR};
 use flake_graph::{
     graph::{NodeGraph, SizeSummary},
     lock::FlakeLock,
@@ -11,6 +11,13 @@ use std::collections::HashMap;
 #[test]
 fn build_simple_lock_graph() {
     let lock = simple_lock();
+    let graph = NodeGraph::from(lock);
+    println!("{}", graph.to_dot(None));
+}
+
+#[test]
+fn build_missing_field_lock_graph() {
+    let lock = missing_fields_lock();
     let graph = NodeGraph::from(lock);
     println!("{}", graph.to_dot(None));
 }

--- a/tests/parse_lock.rs
+++ b/tests/parse_lock.rs
@@ -1,13 +1,22 @@
 pub mod common;
 use pretty_assertions::assert_eq;
 
-use common::{bound_lock, simple_lock, BOUND_LOCK_STR, SIMPLE_LOCK_STR};
+use common::{
+    bound_lock, missing_fields_lock, simple_lock, BOUND_LOCK_STR, MISSING_FIELDS_LOCK_STR,
+    SIMPLE_LOCK_STR,
+};
 use flake_graph::lock::FlakeLock;
 
 #[test]
 fn parse_simple_lock() {
     let parsed: FlakeLock = serde_json::from_str(SIMPLE_LOCK_STR).unwrap();
     assert_eq!(parsed, simple_lock());
+}
+
+#[test]
+fn parse_missing_fields_lock() {
+    let parsed: FlakeLock = serde_json::from_str(MISSING_FIELDS_LOCK_STR).unwrap();
+    assert_eq!(parsed, missing_fields_lock());
 }
 
 #[test]


### PR DESCRIPTION
This PR implements support for handling some missing fields in the `flake.lock`, as well as adding support for `file` input variant (maybe specific to DetNix generating the `flake.lock`).

When parsing my `flake.lock`, I encountered the following issues (after fixing the previous one, the next one appears).

```shellSession
$ nix shell github:nikitawootten/flake-graph nixpkgs#graphviz \
    --command sh -c 'flake-graph flake.lock | dot -Tsvg > flake-lock.svg'
thread 'main' (1279511) panicked at src/main.rs:23:36:
Should have been able to parse flake lock: Error("missing field `lastModified`", line: 200, column: 7)

$ !!
thread 'main' (1281229) panicked at src/main.rs:23:36:
Should have been able to parse flake lock: Error("unknown variant `file`, expected one of `git`, `github`, `gitlab`, `indirect`, `tarball`, `path`", line: 200, column: 7)

$ !!
thread 'main' (1287272) panicked at src/main.rs:23:36:
Should have been able to parse flake lock: Error("missing field `host`", line: 1324, column: 7)
```

`flake-graph` fails to parse the following `flake.lock` lockfile on several inputs. Notably, these include:

1. input with `locked` object missing `lastModified` field,
2. input variant `file`,
3. input with `original` object for `gitlab.com` host missing `host` field.

<details>
<summary>flake.lock</summary>

```json
{
  "nodes": {
    "auto-cpufreq": {
      "inputs": {
        "nixpkgs": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1778403279,
        "narHash": "sha256-qOn95CiAxdt+x0YV5Qrc039HFpByEvURVCHPzCVr8tE=",
        "owner": "AdnanHodzic",
        "repo": "auto-cpufreq",
        "rev": "c1ba0fe5df2542681e8dfcef6b0aa0217cf9edb4",
        "type": "github"
      },
      "original": {
        "owner": "AdnanHodzic",
        "repo": "auto-cpufreq",
        "type": "github"
      }
    },
    "cachix": {
      "inputs": {
        "devenv": [
          "devenv"
        ],
        "flake-compat": [
          "devenv",
          "flake-compat"
        ],
        "git-hooks": [
          "devenv",
          "git-hooks"
        ],
        "nixpkgs": [
          "devenv",
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1777487137,
        "narHash": "sha256-TuvKVBX60mqyMT6OB5JqVEh1YIWtFMR/igLCaCdC9tw=",
        "owner": "cachix",
        "repo": "cachix",
        "rev": "a66a440c321d35f7193472c317f42a55ccd1cb93",
        "type": "github"
      },
      "original": {
        "owner": "cachix",
        "ref": "latest",
        "repo": "cachix",
        "type": "github"
      }
    },
    "cf": {
      "locked": {
        "lastModified": 1756852014,
        "narHash": "sha256-OrfTRBwerFrlK1fbWhu1eW40XUrOdE/Rq7IyxthEpcA=",
        "owner": "jzbor",
        "repo": "cornflakes",
        "rev": "7ef6d8be9b66f46cee3af1d5797e01f301b93149",
        "type": "github"
      },
      "original": {
        "owner": "jzbor",
        "repo": "cornflakes",
        "type": "github"
      }
    },
    "crane": {
      "locked": {
        "lastModified": 1780099841,
        "narHash": "sha256-EVZd2RsbpreRUDSi9rBwPY+ZxoyMaiEBbZxxhljbaS4=",
        "owner": "ipetkov",
        "repo": "crane",
        "rev": "0532eb17955225173906d671fb36306bdeb1e2dc",
        "type": "github"
      },
      "original": {
        "owner": "ipetkov",
        "repo": "crane",
        "type": "github"
      }
    },
    "crane_2": {
      "locked": {
        "lastModified": 1762538466,
        "narHash": "sha256-8zrIPl6J+wLm9MH5ksHcW7BUHo7jSNOu0/hA0ohOOaM=",
        "owner": "ipetkov",
        "repo": "crane",
        "rev": "0cea393fffb39575c46b7a0318386467272182fe",
        "type": "github"
      },
      "original": {
        "owner": "ipetkov",
        "repo": "crane",
        "type": "github"
      }
    },
    "crane_3": {
      "locked": {
        "lastModified": 1766774972,
        "narHash": "sha256-8qxEFpj4dVmIuPn9j9z6NTbU+hrcGjBOvaxTzre5HmM=",
        "owner": "ipetkov",
        "repo": "crane",
        "rev": "01bc1d404a51a0a07e9d8759cd50a7903e218c82",
        "type": "github"
      },
      "original": {
        "owner": "ipetkov",
        "repo": "crane",
        "type": "github"
      }
    },
    "crate2nix": {
      "flake": false,
      "locked": {
        "lastModified": 1772186516,
        "narHash": "sha256-8s28pzmQ6TOIUzznwFibtW1CMieMUl1rYJIxoQYor58=",
        "owner": "rossng",
        "repo": "crate2nix",
        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
        "type": "github"
      },
      "original": {
        "owner": "rossng",
        "repo": "crate2nix",
        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
        "type": "github"
      }
    },
    "den": {
      "locked": {
        "lastModified": 1780098105,
        "narHash": "sha256-uTh8BcraCGcLVkQPaTpPo6jNqp+vqGXokxzsCkRo9KQ=",
        "owner": "denful",
        "repo": "den",
        "rev": "30ebfdc1b6b3e02f668b2559c0af75cbd1cfe086",
        "type": "github"
      },
      "original": {
        "owner": "denful",
        "repo": "den",
        "type": "github"
      }
    },
    "dendrix": {
      "inputs": {
        "import-tree": [
          "import-tree"
        ],
        "nixpkgs-lib": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1769548514,
        "narHash": "sha256-84FoW3FrAXgzE4iXyDjLIQrfUEkNCfMA/uDcu1Y/cno=",
        "owner": "denful",
        "repo": "dendrix",
        "rev": "ffea5e597bd1c5f8d35d51545c67cff984a0ff40",
        "type": "github"
      },
      "original": {
        "owner": "denful",
        "repo": "dendrix",
        "type": "github"
      }
    },
    "determinate": {
      "inputs": {
        "determinate-nixd-aarch64-darwin": "determinate-nixd-aarch64-darwin",
        "determinate-nixd-aarch64-linux": "determinate-nixd-aarch64-linux",
        "determinate-nixd-x86_64-linux": "determinate-nixd-x86_64-linux",
        "nix": "nix",
        "nixpkgs": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1779475417,
        "narHash": "sha256-7/U/+X66C7XmLnt5JVJVtpx8wVDRU//Awaeqkq9+NNc=",
        "rev": "8a9c57ea6b458a40589df60f26200b7d305354d1",
        "revCount": 417,
        "type": "tarball",
        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/determinate/3.21.0/019e5103-0940-7a50-bac6-f1c621bf31ff/source.tar.gz"
      },
      "original": {
        "type": "tarball",
        "url": "https://flakehub.com/f/DeterminateSystems/determinate/%2A"
      }
    },
    "determinate-nixd-aarch64-darwin": {
      "flake": false,
      "locked": {
        "narHash": "sha256-LNvx0qZsH8tbdgNfaig/x5Cf4r4UrXfU1m+0bO3D0E4=",
        "type": "file",
        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.21.0/macOS"
      },
      "original": {
        "type": "file",
        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.21.0/macOS"
      }
    },
    "determinate-nixd-aarch64-linux": {
      "flake": false,
      "locked": {
        "narHash": "sha256-rKg7uVAEK8X3TTFGaWp8CVZuCAr3wHkMnuJOndhXJF0=",
        "type": "file",
        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.21.0/aarch64-linux"
      },
      "original": {
        "type": "file",
        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.21.0/aarch64-linux"
      }
    },
    "determinate-nixd-x86_64-linux": {
      "flake": false,
      "locked": {
        "narHash": "sha256-vBCUEVPfY4+nxGDM62evpxJYEVqLTqdBGbCkmZ2sQhk=",
        "type": "file",
        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.21.0/x86_64-linux"
      },
      "original": {
        "type": "file",
        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.21.0/x86_64-linux"
      }
    },
    "devenv": {
      "inputs": {
        "cachix": "cachix",
        "crate2nix": "crate2nix",
        "flake-compat": [
          "flake-compat"
        ],
        "flake-parts": [
          "flake-parts"
        ],
        "ghostty": "ghostty",
        "git-hooks": [
          "git-hooks-nix"
        ],
        "nix": "nix_2",
        "nixd": "nixd",
        "nixpkgs": [
          "nixpkgs"
        ],
        "rust-overlay": "rust-overlay"
      },
      "locked": {
        "lastModified": 1780630679,
        "narHash": "sha256-hhQyVAYmNKziZ0T+T4Gsk0PYmnz4vdzOzpkJAmDASKM=",
        "owner": "cachix",
        "repo": "devenv",
        "rev": "90ed6227ab389dd4e874a69a724f25dba312b754",
        "type": "github"
      },
      "original": {
        "owner": "cachix",
        "repo": "devenv",
        "type": "github"
      }
    },
    "devshell": {
      "inputs": {
        "nixpkgs": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1768818222,
        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
        "owner": "numtide",
        "repo": "devshell",
        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
        "type": "github"
      },
      "original": {
        "owner": "numtide",
        "repo": "devshell",
        "type": "github"
      }
    },
    "devshell_2": {
      "inputs": {
        "nixpkgs": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1768818222,
        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
        "owner": "numtide",
        "repo": "devshell",
        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
        "type": "github"
      },
      "original": {
        "owner": "numtide",
        "repo": "devshell",
        "type": "github"
      }
    },
    "direnv-instant": {
      "inputs": {
        "flake-parts": [
          "flake-parts"
        ],
        "nixpkgs": [
          "nixpkgs"
        ],
        "treefmt-nix": "treefmt-nix_2"
      },
      "locked": {
        "lastModified": 1780557299,
        "narHash": "sha256-FF1zYCdsh9q1QS8kFMYYGiaDUzxdBBfdtQT+x/15CpA=",
        "owner": "Mic92",
        "repo": "direnv-instant",
        "rev": "0df681e3c0d544d7dc723cc9750a50cfc37b0095",
        "type": "github"
      },
      "original": {
        "owner": "Mic92",
        "repo": "direnv-instant",
        "type": "github"
      }
    },
    "disko": {
      "inputs": {
        "nixpkgs": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1780290312,
        "narHash": "sha256-eTAlX0CwgB84Ts3GaBd944A3DRXVMzgA0EqroZBISUo=",
        "owner": "nix-community",
        "repo": "disko",
        "rev": "115e5211780054d8a890b41f0b7734cafad54dfe",
        "type": "github"
      },
      "original": {
        "owner": "nix-community",
        "repo": "disko",
        "type": "github"
      }
    },
    "editorconfig": {
      "flake": false,
      "locked": {
        "lastModified": 1748032927,
        "narHash": "sha256-Z/AyBi5qgI6jAlBmMtyAYa1y4ujrBqYd6GDUt40wER4=",
        "owner": "Ookiiboy",
        "repo": "editor-config",
        "rev": "1baed1b2d90db36ddf59ad6c886d74f8d5d4aad3",
        "type": "github"
      },
      "original": {
        "owner": "Ookiiboy",
        "repo": "editor-config",
        "type": "github"
      }
    },
    "envoluntary": {
      "inputs": {
        "crane": "crane",
        "devshell": "devshell_2",
        "flake-parts": [
          "flake-parts"
        ],
        "home-manager": [
          "home-manager"
        ],
        "nixpkgs": [
          "nixpkgs"
        ],
        "rust-overlay": "rust-overlay_2"
      },
      "locked": {
        "lastModified": 1780196915,
        "narHash": "sha256-avUK7MGEYOKimNIUrgkzQ53cPu79PE7AIZ/b2u6pb4w=",
        "owner": "dfrankland",
        "repo": "envoluntary",
        "rev": "68fb6d61857a2facdb9e78da5c39c19f85197e96",
        "type": "github"
      },
      "original": {
        "owner": "dfrankland",
        "repo": "envoluntary",
        "type": "github"
      }
    },
    "files": {
      "flake": false,
      "locked": {
        "lastModified": 1779698958,
        "narHash": "sha256-r7ugq8xp1cPX0TNBpPoZnq7t6VoN44pfD1zCjDvcCgE=",
        "owner": "mightyiam",
        "repo": "files",
        "rev": "bec7bba1cfd70a6305c8a690b33dac5771812a28",
        "type": "github"
      },
      "original": {
        "owner": "mightyiam",
        "repo": "files",
        "rev": "bec7bba1cfd70a6305c8a690b33dac5771812a28",
        "type": "github"
      }
    },
    "flake-aspects": {
      "locked": {
        "lastModified": 1773552804,
        "narHash": "sha256-a0kjpCZGnD5lt7yW6C3hzPhSf5KjnTyvX6XZ2NuhGs4=",
        "owner": "denful",
        "repo": "flake-aspects",
        "rev": "56fa8d4d4772d58eb7f9d66c28c1cd2762b60423",
        "type": "github"
      },
      "original": {
        "owner": "denful",
        "repo": "flake-aspects",
        "type": "github"
      }
    },
    "flake-compat": {
      "flake": false,
      "locked": {
        "lastModified": 1696426674,
        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
        "owner": "edolstra",
        "repo": "flake-compat",
        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
        "type": "github"
      },
      "original": {
        "owner": "edolstra",
        "repo": "flake-compat",
        "type": "github"
      }
    },
    "flake-compat_2": {
      "locked": {
        "lastModified": 1761640442,
        "narHash": "sha256-AtrEP6Jmdvrqiv4x2xa5mrtaIp3OEe8uBYCDZDS+hu8=",
        "owner": "nix-community",
        "repo": "flake-compat",
        "rev": "4a56054d8ffc173222d09dad23adf4ba946c8884",
        "type": "github"
      },
      "original": {
        "owner": "nix-community",
        "repo": "flake-compat",
        "type": "github"
      }
    },
    "flake-file": {
      "locked": {
        "lastModified": 1779051720,
        "narHash": "sha256-+jbXnODsR19pFKB0x/6kHhFgW6yV6N+CGClFr45eDU8=",
        "owner": "vic",
        "repo": "flake-file",
        "rev": "c58eb27d9434e5be0c8693f1eb18d47035bc21ba",
        "type": "github"
      },
      "original": {
        "owner": "vic",
        "repo": "flake-file",
        "type": "github"
      }
    },
    "flake-graph": {
      "inputs": {
        "nixpkgs": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1780845096,
        "narHash": "sha256-7EbhNSJ8xE2i8h/xAppVHMLw16E/sxZRTw2JvG8cgH8=",
        "path": "/home/adda/documents/it/nixos/flake-graph",
        "type": "path"
      },
      "original": {
        "path": "/home/adda/documents/it/nixos/flake-graph",
        "type": "path"
      }
    },
    "flake-parts": {
      "inputs": {
        "nixpkgs-lib": [
          "determinate",
          "nix",
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1748821116,
        "narHash": "sha256-F82+gS044J1APL0n4hH50GYdPRv/5JWm34oCJYmVKdE=",
        "rev": "49f0870db23e8c1ca0b5259734a02cd9e1e371a1",
        "revCount": 377,
        "type": "tarball",
        "url": "https://api.flakehub.com/f/pinned/hercules-ci/flake-parts/0.1.377%2Brev-49f0870db23e8c1ca0b5259734a02cd9e1e371a1/01972f28-554a-73f8-91f4-d488cc502f08/source.tar.gz"
      },
      "original": {
        "type": "tarball",
        "url": "https://flakehub.com/f/hercules-ci/flake-parts/0.1"
      }
    },
    "flake-parts_2": {
      "inputs": {
        "nixpkgs-lib": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1778716662,
        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
        "owner": "hercules-ci",
        "repo": "flake-parts",
        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
        "type": "github"
      },
      "original": {
        "owner": "hercules-ci",
        "repo": "flake-parts",
        "type": "github"
      }
    },
    "flake-utils": {
      "inputs": {
        "systems": [
          "systems"
        ]
      },
      "locked": {
        "lastModified": 1731533236,
        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
        "owner": "numtide",
        "repo": "flake-utils",
        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
        "type": "github"
      },
      "original": {
        "owner": "numtide",
        "repo": "flake-utils",
        "type": "github"
      }
    },
    "flake-utils_2": {
      "inputs": {
        "systems": "systems"
      },
      "locked": {
        "lastModified": 1731533236,
        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
        "owner": "numtide",
        "repo": "flake-utils",
        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
        "type": "github"
      },
      "original": {
        "owner": "numtide",
        "repo": "flake-utils",
        "type": "github"
      }
    },
    "flake-utils_3": {
      "inputs": {
        "systems": "systems_2"
      },
      "locked": {
        "lastModified": 1731533236,
        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
        "owner": "numtide",
        "repo": "flake-utils",
        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
        "type": "github"
      },
      "original": {
        "owner": "numtide",
        "repo": "flake-utils",
        "type": "github"
      }
    },
    "ghostty": {
      "flake": false,
      "locked": {
        "lastModified": 1779069789,
        "narHash": "sha256-ojo+gso45/6CVSuqfSVnlWpQ4d0QeLgwok+v/g3yu0E=",
        "owner": "ghostty-org",
        "repo": "ghostty",
        "rev": "4b7bf0b20e3baf9c1ba10c63f2ad1fd853faea8f",
        "type": "github"
      },
      "original": {
        "owner": "ghostty-org",
        "repo": "ghostty",
        "type": "github"
      }
    },
    "git-hooks-nix": {
      "inputs": {
        "flake-compat": "flake-compat",
        "gitignore": [
          "determinate",
          "nix"
        ],
        "nixpkgs": [
          "determinate",
          "nix",
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1747372754,
        "narHash": "sha256-2Y53NGIX2vxfie1rOW0Qb86vjRZ7ngizoo+bnXU9D9k=",
        "rev": "80479b6ec16fefd9c1db3ea13aeb038c60530f46",
        "revCount": 1026,
        "type": "tarball",
        "url": "https://api.flakehub.com/f/pinned/cachix/git-hooks.nix/0.1.1026%2Brev-80479b6ec16fefd9c1db3ea13aeb038c60530f46/0196d79a-1b35-7b8e-a021-c894fb62163d/source.tar.gz"
      },
      "original": {
        "type": "tarball",
        "url": "https://flakehub.com/f/cachix/git-hooks.nix/0.1.941"
      }
    },
    "git-hooks-nix_2": {
      "inputs": {
        "flake-compat": [
          "flake-compat"
        ],
        "gitignore": "gitignore",
        "nixpkgs": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1778507602,
        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
        "owner": "cachix",
        "repo": "git-hooks.nix",
        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
        "type": "github"
      },
      "original": {
        "owner": "cachix",
        "repo": "git-hooks.nix",
        "type": "github"
      }
    },
    "github-gitignore": {
      "flake": false,
      "locked": {
        "lastModified": 1779407372,
        "narHash": "sha256-6iCmlbxb27MGtHqQGj98LUnmK17QCdCYCwgIlyYC6MM=",
        "owner": "github",
        "repo": "gitignore",
        "rev": "dcc0fc7bc2b5ba480cf117ad1be31bafceeaff46",
        "type": "github"
      },
      "original": {
        "owner": "github",
        "repo": "gitignore",
        "type": "github"
      }
    },
    "gitignore": {
      "inputs": {
        "nixpkgs": [
          "git-hooks-nix",
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1709087332,
        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
        "owner": "hercules-ci",
        "repo": "gitignore.nix",
        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
        "type": "github"
      },
      "original": {
        "owner": "hercules-ci",
        "repo": "gitignore.nix",
        "type": "github"
      }
    },
    "helix": {
      "inputs": {
        "nixpkgs": "nixpkgs_2",
        "rust-overlay": "rust-overlay_3"
      },
      "locked": {
        "lastModified": 1780642964,
        "narHash": "sha256-GJU6FNPEf5CkJxsHa+1FIjQ3lWBH77DmcrVDeDgsk9g=",
        "owner": "helix-editor",
        "repo": "helix",
        "rev": "7eb1a2874af919caab8e69cf8bb6222d32fa6445",
        "type": "github"
      },
      "original": {
        "owner": "helix-editor",
        "repo": "helix",
        "type": "github"
      }
    },
    "hjem": {
      "inputs": {
        "nix-darwin": [
          "hjem-rum",
          "nix-darwin"
        ],
        "nixpkgs": [
          "hjem-rum",
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1779575248,
        "narHash": "sha256-Zh9+WMsxDbLVWwhccXjLW+PYO/5ZyUFQLZdYydycbx8=",
        "owner": "feel-co",
        "repo": "hjem",
        "rev": "77bf113e3ce91c6632def66222198561437853dc",
        "type": "github"
      },
      "original": {
        "owner": "feel-co",
        "repo": "hjem",
        "type": "github"
      }
    },
    "hjem-rum": {
      "inputs": {
        "hjem": "hjem",
        "nix-darwin": "nix-darwin",
        "nixpkgs": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1779599065,
        "narHash": "sha256-L35xnhNcCJIHTkwmpey/sBFZMnPm2eD9Ha4NCwWuy68=",
        "owner": "snugnug",
        "repo": "hjem-rum",
        "rev": "e04efc81865f68f541471186090cc703d99bc62d",
        "type": "github"
      },
      "original": {
        "owner": "snugnug",
        "repo": "hjem-rum",
        "type": "github"
      }
    },
    "home-manager": {
      "inputs": {
        "nixpkgs": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1780593650,
        "narHash": "sha256-CHo7k65YTL3HY+WQVedDTupji+LMgNlKCdrtRHZFAK4=",
        "owner": "nix-community",
        "repo": "home-manager",
        "rev": "447fd9ff62501dae7206dfe180ee89f8de27b7d5",
        "type": "github"
      },
      "original": {
        "owner": "nix-community",
        "repo": "home-manager",
        "type": "github"
      }
    },
    "ignoreBoy": {
      "inputs": {
        "editorconfig": "editorconfig",
        "gitignore-repo": [
          "github-gitignore"
        ],
        "nixpkgs": [
          "nixpkgs"
        ],
        "pre-commit-hooks": [
          "git-hooks-nix"
        ],
        "systems": [
          "systems"
        ]
      },
      "locked": {
        "lastModified": 1750956671,
        "narHash": "sha256-ataHJ9GIOKE1XetwLl18zKIeM5IyV2VlrlObLNcuY98=",
        "owner": "Ookiiboy",
        "repo": "ignoreBoy",
        "rev": "7341a4ba4e290fa164005a92f7ab2a5abb253bad",
        "type": "github"
      },
      "original": {
        "owner": "Ookiiboy",
        "repo": "ignoreBoy",
        "type": "github"
      }
    },
    "import-tree": {
      "locked": {
        "lastModified": 1778781969,
        "narHash": "sha256-Jjuz5CmSkur8KvLDoGa+vylEp+RkQtv4mt/qcMznpH0=",
        "owner": "vic",
        "repo": "import-tree",
        "rev": "d321337efd0f23a9eb14a42adb7b2c29313ab274",
        "type": "github"
      },
      "original": {
        "owner": "vic",
        "repo": "import-tree",
        "type": "github"
      }
    },
    "jjui": {
      "inputs": {
        "flake-parts": [
          "flake-parts"
        ],
        "nixpkgs": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1779830045,
        "narHash": "sha256-LqZN7ElQTALW3XYUqOxcHxdUQO6DkF4YwoxFVnC3M74=",
        "owner": "idursun",
        "repo": "jjui",
        "rev": "281650c7e24389d97a68561b96d0b885e7279983",
        "type": "github"
      },
      "original": {
        "owner": "idursun",
        "ref": "main",
        "repo": "jjui",
        "type": "github"
      }
    },
    "libSource": {
      "locked": {
        "lastModified": 1754184128,
        "narHash": "sha256-AjhoyBL4eSyXf01Bmc6DiuaMrJRNdWopmdnMY0Pa/M0=",
        "owner": "divnix",
        "repo": "nixpkgs.lib",
        "rev": "02e72200e6d56494f4a7c0da8118760736e41b60",
        "type": "github"
      },
      "original": {
        "owner": "divnix",
        "repo": "nixpkgs.lib",
        "type": "github"
      }
    },
    "libSource_2": {
      "locked": {
        "lastModified": 1753579242,
        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
        "owner": "divnix",
        "repo": "nixpkgs.lib",
        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
        "type": "github"
      },
      "original": {
        "owner": "divnix",
        "repo": "nixpkgs.lib",
        "type": "github"
      }
    },
    "make-shell": {
      "inputs": {
        "flake-compat": [
          "flake-compat"
        ]
      },
      "locked": {
        "lastModified": 1733933815,
        "narHash": "sha256-9JjM7eT66W4NJAXpGUsdyAFXhBxFWR2Z9LZwUa7Hli0=",
        "owner": "nicknovitski",
        "repo": "make-shell",
        "rev": "ffeceae9956df03571ea8e96ef77c2924f13a63c",
        "type": "github"
      },
      "original": {
        "owner": "nicknovitski",
        "repo": "make-shell",
        "type": "github"
      }
    },
    "nix": {
      "inputs": {
        "flake-parts": "flake-parts",
        "git-hooks-nix": "git-hooks-nix",
        "nixpkgs": "nixpkgs",
        "nixpkgs-23-11": "nixpkgs-23-11",
        "nixpkgs-regression": "nixpkgs-regression"
      },
      "locked": {
        "lastModified": 1779472733,
        "narHash": "sha256-nV5OHwivEf392cB5MDwoVdDHSvy6Q+rRYZBHd9sePj4=",
        "rev": "11f3aff904f84ae612e36e8bc578ac421fca74fa",
        "revCount": 25967,
        "type": "tarball",
        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nix-src/3.21.0/019e50fb-8633-73d0-b673-b2e265950490/source.tar.gz"
      },
      "original": {
        "type": "tarball",
        "url": "https://flakehub.com/f/DeterminateSystems/nix-src/%2A"
      }
    },
    "nix-darwin": {
      "inputs": {
        "nixpkgs": [
          "hjem-rum",
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1779036909,
        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
        "owner": "nix-darwin",
        "repo": "nix-darwin",
        "rev": "56c666e108467d87d13508936aade6d567f2a501",
        "type": "github"
      },
      "original": {
        "owner": "nix-darwin",
        "repo": "nix-darwin",
        "type": "github"
      }
    },
    "nix-direnv": {
      "inputs": {
        "flake-parts": [
          "flake-parts"
        ],
        "nixpkgs": [
          "nixpkgs"
        ],
        "treefmt-nix": "treefmt-nix_3"
      },
      "locked": {
        "lastModified": 1780275711,
        "narHash": "sha256-B30XhPvFxPO6rjOJf25O/utHedn52K0iLWxkAGOhTwo=",
        "owner": "nix-community",
        "repo": "nix-direnv",
        "rev": "e6e7b3537c3c08650c5bfb3de480118ed62e5de5",
        "type": "github"
      },
      "original": {
        "owner": "nix-community",
        "repo": "nix-direnv",
        "type": "github"
      }
    },
    "nix-flatpak": {
      "locked": {
        "lastModified": 1779998907,
        "narHash": "sha256-8CSkdFNkAF49pmhFneEFNAO4UX9/0FnoMwXMY3yyvi0=",
        "owner": "gmodena",
        "repo": "nix-flatpak",
        "rev": "744221c2aef17f1f2a13278abfeabd9bd5e40180",
        "type": "github"
      },
      "original": {
        "owner": "gmodena",
        "repo": "nix-flatpak",
        "type": "github"
      }
    },
    "nix-formatter-pack": {
      "inputs": {
        "nixpkgs": [
          "nixpkgs"
        ],
        "nmd": "nmd",
        "nmt": "nmt"
      },
      "locked": {
        "lastModified": 1778074909,
        "narHash": "sha256-kO3+QMRbNrhVPQ6yd1DoovTi9Vp0xQLQ7FnAvHGLTaU=",
        "owner": "Gerschtli",
        "repo": "nix-formatter-pack",
        "rev": "14a8e67a835271a8294ad84d49243a5b12a73cf9",
        "type": "github"
      },
      "original": {
        "owner": "Gerschtli",
        "repo": "nix-formatter-pack",
        "type": "github"
      }
    },
    "nix-index-database": {
      "inputs": {
        "nixpkgs": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1780210899,
        "narHash": "sha256-4axz3OBPTKa6LIkXV8n0lc63MQU+et2CB5DGobEAi6k=",
        "owner": "nix-community",
        "repo": "nix-index-database",
        "rev": "97df9dc0b7c924344b793a15c1e8e4522ebb854e",
        "type": "github"
      },
      "original": {
        "owner": "nix-community",
        "repo": "nix-index-database",
        "type": "github"
      }
    },
    "nix-maid": {
      "locked": {
        "lastModified": 1775372244,
        "narHash": "sha256-pLCCqY/0JC7QdWqyEyDEvGl63f9aS8zrFLVJW7gUMKI=",
        "owner": "viperML",
        "repo": "nix-maid",
        "rev": "993d95a0a5b2f4b06faa022b32112b699ca3bbfd",
        "type": "github"
      },
      "original": {
        "owner": "viperML",
        "repo": "nix-maid",
        "type": "github"
      }
    },
    "nix-sweep": {
      "inputs": {
        "cf": "cf",
        "crane": "crane_2",
        "nixpkgs": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1777567981,
        "narHash": "sha256-8ZVUoerhitQdBRtQalX0US1Nmc4c9cRGDhBpfAPH51w=",
        "owner": "jzbor",
        "repo": "nix-sweep",
        "rev": "b3f71b38917ec9701a505ae3caa6907ccc6b5380",
        "type": "github"
      },
      "original": {
        "owner": "jzbor",
        "repo": "nix-sweep",
        "type": "github"
      }
    },
    "nix-unit": {
      "inputs": {
        "nix-github-actions": [],
        "nixpkgs": [
          "nixpkgs"
        ],
        "treefmt-nix": [
          "treefmt-nix"
        ]
      },
      "locked": {
        "lastModified": 1779338171,
        "narHash": "sha256-affUbv/bwE8SLGhuWKniDr7SVO+Lo1XEPjCZdyU5kgQ=",
        "owner": "nix-community",
        "repo": "nix-unit",
        "rev": "6ab1f232562a01d18b40d5ed6a58718c4f3a74bc",
        "type": "github"
      },
      "original": {
        "owner": "nix-community",
        "repo": "nix-unit",
        "type": "github"
      }
    },
    "nix-version-search-cli": {
      "inputs": {
        "flakeUtils": [
          "flake-utils"
        ],
        "home-manager": [
          "home-manager"
        ],
        "libSource": "libSource",
        "nixpkgs": [
          "nixpkgs"
        ],
        "xome": "xome"
      },
      "locked": {
        "lastModified": 1761578212,
        "narHash": "sha256-M5b+YI7l6HKUfDJArH561XSn/zKsRyu6ekXy8KiIXtY=",
        "owner": "jeff-hykin",
        "repo": "nix_version_search_cli",
        "rev": "8053f87f566c1a4d61cfb53436eafd0331918902",
        "type": "github"
      },
      "original": {
        "owner": "jeff-hykin",
        "repo": "nix_version_search_cli",
        "type": "github"
      }
    },
    "nix4vscode": {
      "inputs": {
        "nixpkgs": [
          "nixpkgs"
        ],
        "systems": [
          "systems"
        ]
      },
      "locked": {
        "lastModified": 1780633669,
        "narHash": "sha256-vfIgceYs5gyJ7VXP+JtaAHWg/ukIecjW0leK93bdytw=",
        "owner": "nix-community",
        "repo": "nix4vscode",
        "rev": "9c81fa6f3809b57af8ba1a8ed36e65555c493ea6",
        "type": "github"
      },
      "original": {
        "owner": "nix-community",
        "repo": "nix4vscode",
        "type": "github"
      }
    },
    "nix_2": {
      "inputs": {
        "flake-compat": [
          "devenv",
          "flake-compat"
        ],
        "flake-parts": [
          "devenv",
          "flake-parts"
        ],
        "git-hooks-nix": [
          "devenv",
          "git-hooks"
        ],
        "nixpkgs": [
          "devenv",
          "nixpkgs"
        ],
        "nixpkgs-23-11": [
          "devenv"
        ],
        "nixpkgs-regression": [
          "devenv"
        ]
      },
      "locked": {
        "lastModified": 1779748925,
        "narHash": "sha256-meIhqGC04O5VXbKSFXSQoOKp+XCq5RMnwAk1Guo0VQo=",
        "owner": "cachix",
        "repo": "nix",
        "rev": "0bc443c8ff235c3547d09327b48aaa2ab98b15f2",
        "type": "github"
      },
      "original": {
        "owner": "cachix",
        "ref": "devenv-2.34",
        "repo": "nix",
        "type": "github"
      }
    },
    "nixd": {
      "inputs": {
        "flake-parts": [
          "devenv",
          "flake-parts"
        ],
        "nixpkgs": [
          "devenv",
          "nixpkgs"
        ],
        "treefmt-nix": "treefmt-nix"
      },
      "locked": {
        "lastModified": 1778381404,
        "narHash": "sha256-FqhdOTA8vyoIpkHhbs2cCT7h6EWM7nsLeOYJc1ifQLE=",
        "owner": "nix-community",
        "repo": "nixd",
        "rev": "e3e45eb76663f522e196b7f0cf34cab201db7779",
        "type": "github"
      },
      "original": {
        "owner": "nix-community",
        "repo": "nixd",
        "type": "github"
      }
    },
    "nixos-hardware": {
      "inputs": {
        "nixpkgs": "nixpkgs_3"
      },
      "locked": {
        "lastModified": 1780310866,
        "narHash": "sha256-fPBRVf6A5xlACYcOI59shGrjURuvwu0lRsDoSCEXt/I=",
        "owner": "NixOS",
        "repo": "nixos-hardware",
        "rev": "4ed851c979641e28597a05086332d75cdc9e395f",
        "type": "github"
      },
      "original": {
        "owner": "NixOS",
        "ref": "master",
        "repo": "nixos-hardware",
        "type": "github"
      }
    },
    "nixpkgs": {
      "locked": {
        "lastModified": 1773222311,
        "narHash": "sha256-BHoB/XpbqoZkVYZCfXJXfkR+GXFqwb/4zbWnOr2cRcU=",
        "rev": "0590cd39f728e129122770c029970378a79d076a",
        "revCount": 909248,
        "type": "tarball",
        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2511.909248%2Brev-0590cd39f728e129122770c029970378a79d076a/019ce32b-8ace-7339-b129-cceaa8dd10c6/source.tar.gz"
      },
      "original": {
        "type": "tarball",
        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.2511"
      }
    },
    "nixpkgs-23-11": {
      "locked": {
        "lastModified": 1717159533,
        "narHash": "sha256-oamiKNfr2MS6yH64rUn99mIZjc45nGJlj9eGth/3Xuw=",
        "owner": "NixOS",
        "repo": "nixpkgs",
        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
        "type": "github"
      },
      "original": {
        "owner": "NixOS",
        "repo": "nixpkgs",
        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
        "type": "github"
      }
    },
    "nixpkgs-regression": {
      "locked": {
        "lastModified": 1643052045,
        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
        "owner": "NixOS",
        "repo": "nixpkgs",
        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
        "type": "github"
      },
      "original": {
        "owner": "NixOS",
        "repo": "nixpkgs",
        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
        "type": "github"
      }
    },
    "nixpkgs-stable": {
      "locked": {
        "lastModified": 1780453794,
        "narHash": "sha256-hhAl/iKiurXPn7rdzDgiSuRB8tqOB6f0buWkh8Y9mkY=",
        "rev": "6b316287bae2ee04c9b93c8c858d930fd07d7338",
        "type": "tarball",
        "url": "https://releases.nixos.org/nixos/26.05/nixos-26.05.1183.6b316287bae2/nixexprs.tar.xz"
      },
      "original": {
        "type": "tarball",
        "url": "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz"
      }
    },
    "nixpkgs_2": {
      "locked": {
        "lastModified": 1775036866,
        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
        "owner": "nixos",
        "repo": "nixpkgs",
        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
        "type": "github"
      },
      "original": {
        "owner": "nixos",
        "ref": "nixos-unstable",
        "repo": "nixpkgs",
        "type": "github"
      }
    },
    "nixpkgs_3": {
      "locked": {
        "lastModified": 1767892417,
        "narHash": "sha256-8bW3q88CEg2u4hSP66Vf4lpbLonHz7hqDNBMcCY7E9U=",
        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
        "type": "tarball",
        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre924538.3497aa5c9457/nixexprs.tar.xz"
      },
      "original": {
        "type": "tarball",
        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
      }
    },
    "nixpkgs_4": {
      "locked": {
        "lastModified": 1780243769,
        "narHash": "sha256-2fYATYjjbsF2ri3reTWXgBkrmwK5Hpj23CsTEdLA2fo=",
        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
        "type": "tarball",
        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1008282.331800de5053/nixexprs.tar.xz"
      },
      "original": {
        "type": "tarball",
        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
      }
    },
    "nmd": {
      "flake": false,
      "locked": {
        "lastModified": 1666190571,
        "narHash": "sha256-Z1hc7M9X6L+H83o9vOprijpzhTfOBjd0KmUTnpHAVjA=",
        "owner": "rycee",
        "repo": "nmd",
        "rev": "b75d312b4f33bd3294cd8ae5c2ca8c6da2afc169",
        "type": "gitlab"
      },
      "original": {
        "owner": "rycee",
        "repo": "nmd",
        "type": "gitlab"
      }
    },
    "nmt": {
      "flake": false,
      "locked": {
        "lastModified": 1648075362,
        "narHash": "sha256-u36WgzoA84dMVsGXzml4wZ5ckGgfnvS0ryzo/3zn/Pc=",
        "owner": "rycee",
        "repo": "nmt",
        "rev": "d83601002c99b78c89ea80e5e6ba21addcfe12ae",
        "type": "gitlab"
      },
      "original": {
        "owner": "rycee",
        "repo": "nmt",
        "type": "gitlab"
      }
    },
    "nu_scripts": {
      "flake": false,
      "locked": {
        "lastModified": 1780521784,
        "narHash": "sha256-pk29HELNbBfQZDoXeLotUUZlRbQx7k168Rcw1JUOnvU=",
        "owner": "nushell",
        "repo": "nu_scripts",
        "rev": "ca79ff62bd3fe0d31cd50762dcb1c8a46883044e",
        "type": "github"
      },
      "original": {
        "owner": "nushell",
        "repo": "nu_scripts",
        "type": "github"
      }
    },
    "nur": {
      "inputs": {
        "flake-parts": [
          "flake-parts"
        ],
        "nixpkgs": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1780658458,
        "narHash": "sha256-FJWkMGwwCZIhhxCFTd55G++3x5RCUrxapPlQKTekNvE=",
        "owner": "nix-community",
        "repo": "NUR",
        "rev": "acab2916133d5bd85cdfd65da8939ab85af37879",
        "type": "github"
      },
      "original": {
        "owner": "nix-community",
        "repo": "NUR",
        "type": "github"
      }
    },
    "nvchad-starter": {
      "flake": false,
      "locked": {
        "lastModified": 1753939018,
        "narHash": "sha256-xdLr6tlU9uA+wu0pqha2br0fdVm+1MjgjbB5awz9ICU=",
        "owner": "NvChad",
        "repo": "starter",
        "rev": "e3572e1f5e1c297212c3deeb17b7863139ce663e",
        "type": "github"
      },
      "original": {
        "owner": "NvChad",
        "ref": "main",
        "repo": "starter",
        "type": "github"
      }
    },
    "nvchad4nix": {
      "inputs": {
        "flake-utils": "flake-utils_3",
        "nixpkgs": [
          "nixpkgs"
        ],
        "nvchad-starter": "nvchad-starter"
      },
      "locked": {
        "lastModified": 1780588301,
        "narHash": "sha256-2MHi4YewvB3ijS30AoP484TVDfC0zp7y9+3Cv0Dp2QA=",
        "owner": "nix-community",
        "repo": "nix4nvchad",
        "rev": "85a12dcb3685991a0fb61dd731b44d3dca5346bd",
        "type": "github"
      },
      "original": {
        "owner": "nix-community",
        "repo": "nix4nvchad",
        "type": "github"
      }
    },
    "pkgs-by-name-for-flake-parts": {
      "locked": {
        "lastModified": 1769286518,
        "narHash": "sha256-F7VlUICvYp2wJKyQqM6d46BNEZCzMQ6dMH9zbmjuybc=",
        "owner": "drupol",
        "repo": "pkgs-by-name-for-flake-parts",
        "rev": "7ba1cd4a9a72c9c6c272018a63f090f2c912a171",
        "type": "github"
      },
      "original": {
        "owner": "drupol",
        "repo": "pkgs-by-name-for-flake-parts",
        "type": "github"
      }
    },
    "plasma-manager": {
      "inputs": {
        "home-manager": [
          "home-manager"
        ],
        "nixpkgs": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1775856943,
        "narHash": "sha256-b7Mp7P+q2Md5AGt4rjHfMcBykzMumFTen10ST++AuTU=",
        "owner": "nix-community",
        "repo": "plasma-manager",
        "rev": "a524a6160e6df89f7673ba293cf7d78b559eb1a5",
        "type": "github"
      },
      "original": {
        "owner": "nix-community",
        "repo": "plasma-manager",
        "type": "github"
      }
    },
    "root": {
      "inputs": {
        "auto-cpufreq": "auto-cpufreq",
        "den": "den",
        "dendrix": "dendrix",
        "determinate": "determinate",
        "devenv": "devenv",
        "devshell": "devshell",
        "direnv-instant": "direnv-instant",
        "disko": "disko",
        "envoluntary": "envoluntary",
        "files": "files",
        "flake-aspects": "flake-aspects",
        "flake-compat": "flake-compat_2",
        "flake-file": "flake-file",
        "flake-graph": "flake-graph",
        "flake-parts": "flake-parts_2",
        "flake-utils": "flake-utils",
        "git-hooks-nix": "git-hooks-nix_2",
        "github-gitignore": "github-gitignore",
        "helix": "helix",
        "hjem": [
          "hjem-rum",
          "hjem"
        ],
        "hjem-rum": "hjem-rum",
        "home-manager": "home-manager",
        "ignoreBoy": "ignoreBoy",
        "import-tree": "import-tree",
        "jjui": "jjui",
        "make-shell": "make-shell",
        "nix-direnv": "nix-direnv",
        "nix-flatpak": "nix-flatpak",
        "nix-formatter-pack": "nix-formatter-pack",
        "nix-index-database": "nix-index-database",
        "nix-maid": "nix-maid",
        "nix-sweep": "nix-sweep",
        "nix-unit": "nix-unit",
        "nix-version-search-cli": "nix-version-search-cli",
        "nix4vscode": "nix4vscode",
        "nixos-hardware": "nixos-hardware",
        "nixpkgs": "nixpkgs_4",
        "nixpkgs-stable": "nixpkgs-stable",
        "nu_scripts": "nu_scripts",
        "nur": "nur",
        "nvchad4nix": "nvchad4nix",
        "pkgs-by-name-for-flake-parts": "pkgs-by-name-for-flake-parts",
        "plasma-manager": "plasma-manager",
        "sops-nix": "sops-nix",
        "systems": "systems_3",
        "treefmt-nix": "treefmt-nix_4",
        "tsui": "tsui",
        "xdg-ninja": "xdg-ninja",
        "xremap-flake": "xremap-flake"
      }
    },
    "rust-overlay": {
      "inputs": {
        "nixpkgs": [
          "devenv",
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1779074409,
        "narHash": "sha256-6aXy8Ga41iLVM8ibddFU1O5+wYWcBGNEfZzZuL91eIc=",
        "owner": "oxalica",
        "repo": "rust-overlay",
        "rev": "2a77b5b1dc952f214e8102acdef1622b68515560",
        "type": "github"
      },
      "original": {
        "owner": "oxalica",
        "repo": "rust-overlay",
        "type": "github"
      }
    },
    "rust-overlay_2": {
      "inputs": {
        "nixpkgs": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1780110990,
        "narHash": "sha256-6QBThUi7SuK+dgA+DCaEkQGZN4kYx6DpXmK45+MG9zI=",
        "owner": "oxalica",
        "repo": "rust-overlay",
        "rev": "85570ef134d92a8702de6afd1f6f0209c863fa91",
        "type": "github"
      },
      "original": {
        "owner": "oxalica",
        "repo": "rust-overlay",
        "type": "github"
      }
    },
    "rust-overlay_3": {
      "inputs": {
        "nixpkgs": [
          "helix",
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1775358767,
        "narHash": "sha256-f2eC+WIfhjevCPQILuV08i/kmKZzYZpUvkom/33VxCA=",
        "owner": "oxalica",
        "repo": "rust-overlay",
        "rev": "20fd44bc663daa53a2575e01293e24e681d62244",
        "type": "github"
      },
      "original": {
        "owner": "oxalica",
        "repo": "rust-overlay",
        "type": "github"
      }
    },
    "sops-nix": {
      "inputs": {
        "nixpkgs": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1780547341,
        "narHash": "sha256-Gq8KNx5A7hBB3uGJaj6eQfLDIz5YdLu92gqBcvHvoUo=",
        "owner": "Mic92",
        "repo": "sops-nix",
        "rev": "9ed65852b6257fbeae4355bc24ecfea307ca759a",
        "type": "github"
      },
      "original": {
        "owner": "Mic92",
        "repo": "sops-nix",
        "type": "github"
      }
    },
    "systems": {
      "locked": {
        "lastModified": 1681028828,
        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
        "owner": "nix-systems",
        "repo": "default",
        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
        "type": "github"
      },
      "original": {
        "owner": "nix-systems",
        "repo": "default",
        "type": "github"
      }
    },
    "systems_2": {
      "locked": {
        "lastModified": 1681028828,
        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
        "owner": "nix-systems",
        "repo": "default",
        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
        "type": "github"
      },
      "original": {
        "owner": "nix-systems",
        "repo": "default",
        "type": "github"
      }
    },
    "systems_3": {
      "locked": {
        "lastModified": 1680978846,
        "narHash": "sha256-Gtqg8b/v49BFDpDetjclCYXm8mAnTrUzR0JnE2nv5aw=",
        "owner": "nix-systems",
        "repo": "x86_64-linux",
        "rev": "2ecfcac5e15790ba6ce360ceccddb15ad16d08a8",
        "type": "github"
      },
      "original": {
        "owner": "nix-systems",
        "repo": "x86_64-linux",
        "type": "github"
      }
    },
    "treefmt-nix": {
      "inputs": {
        "nixpkgs": [
          "devenv",
          "nixd",
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1775636079,
        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
        "owner": "numtide",
        "repo": "treefmt-nix",
        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
        "type": "github"
      },
      "original": {
        "owner": "numtide",
        "repo": "treefmt-nix",
        "type": "github"
      }
    },
    "treefmt-nix_2": {
      "inputs": {
        "nixpkgs": [
          "direnv-instant",
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1780220602,
        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
        "owner": "numtide",
        "repo": "treefmt-nix",
        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
        "type": "github"
      },
      "original": {
        "owner": "numtide",
        "repo": "treefmt-nix",
        "type": "github"
      }
    },
    "treefmt-nix_3": {
      "inputs": {
        "nixpkgs": [
          "nix-direnv",
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1775636079,
        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
        "owner": "numtide",
        "repo": "treefmt-nix",
        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
        "type": "github"
      },
      "original": {
        "owner": "numtide",
        "repo": "treefmt-nix",
        "type": "github"
      }
    },
    "treefmt-nix_4": {
      "inputs": {
        "nixpkgs": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1780220602,
        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
        "owner": "numtide",
        "repo": "treefmt-nix",
        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
        "type": "github"
      },
      "original": {
        "owner": "numtide",
        "repo": "treefmt-nix",
        "type": "github"
      }
    },
    "tsui": {
      "inputs": {
        "nixpkgs": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1725553663,
        "narHash": "sha256-PzDC8+42zmnB3XnRISk35jj9SueimZ4kywHlVRmDaWs=",
        "owner": "guibou",
        "repo": "tsui",
        "rev": "66ff849f9d5fbce4cc26b7365fcd0946ec4dab70",
        "type": "github"
      },
      "original": {
        "owner": "guibou",
        "repo": "tsui",
        "type": "github"
      }
    },
    "xdg-ninja": {
      "inputs": {
        "flake-utils": [
          "flake-utils"
        ],
        "nixpkgs": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1778425776,
        "narHash": "sha256-VNYZ9WKspAL2mUb1SDuGxv1MhOCBya7eEMJmy5H99xU=",
        "owner": "b3nj5m1n",
        "repo": "xdg-ninja",
        "rev": "f2ab12bbf1cf60dc3cc9459d122811c55ba88150",
        "type": "github"
      },
      "original": {
        "owner": "b3nj5m1n",
        "repo": "xdg-ninja",
        "type": "github"
      }
    },
    "xome": {
      "inputs": {
        "flake-utils": "flake-utils_2",
        "home-manager": [
          "nix-version-search-cli",
          "home-manager"
        ],
        "libSource": "libSource_2",
        "nixpkgs": [
          "nix-version-search-cli",
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1754692188,
        "narHash": "sha256-vmWLTsnhnYHKxPKZM1BFGbIQvSym49JiGtv1+rjAkCQ=",
        "owner": "jeff-hykin",
        "repo": "xome",
        "rev": "fa436c4880cbb064c1e48c8e898fbe8845b25fc3",
        "type": "github"
      },
      "original": {
        "owner": "jeff-hykin",
        "repo": "xome",
        "type": "github"
      }
    },
    "xremap": {
      "flake": false,
      "locked": {
        "lastModified": 1778852267,
        "narHash": "sha256-vsXojdGdAhtFdOlyBEnnBHvZfcgDhNqMN9axxu6wfb0=",
        "owner": "k0kubun",
        "repo": "xremap",
        "rev": "30e7270a5faee053023b85b3f735a454c72aedcb",
        "type": "github"
      },
      "original": {
        "owner": "k0kubun",
        "ref": "v0.15.7",
        "repo": "xremap",
        "type": "github"
      }
    },
    "xremap-flake": {
      "inputs": {
        "crane": "crane_3",
        "flake-parts": [
          "flake-parts"
        ],
        "nixpkgs": [
          "nixpkgs"
        ],
        "xremap": "xremap"
      },
      "locked": {
        "lastModified": 1778874295,
        "narHash": "sha256-uKB6hUAC9kiMo9KU8bqipB5USj/txhATtl1CPcEVRsI=",
        "owner": "xremap",
        "repo": "nix-flake",
        "rev": "859870faae428299eff1d2bc6eea2be4d027fb86",
        "type": "github"
      },
      "original": {
        "owner": "xremap",
        "repo": "nix-flake",
        "type": "github"
      }
    }
  },
  "root": "root",
  "version": 7
}
```

</details>

All of these issues are fixed by this PR. I also added a test case with the problematic inputs in the `flake.lock`.

I added [`smart-default` crate](https://crates.io/crates/smart-default) to handle the case of an implicit (as is my understanding) `gitlab.com` value for the `host` field in an input from GitLab. Manually implementing the `Default` trait for this field is verbose and gets repetitive (defining custom structs implementing the `Default` trait), while this crate is well-used and may be useful in the future for similar situations.